### PR TITLE
SYNR-1445 - support R4 deploys

### DIFF
--- a/r-pkg/deploy.R
+++ b/r-pkg/deploy.R
@@ -46,7 +46,7 @@ deploy_artifact <- function(artifact_file,
         contribUrlType <- 'source'
     } else if (endsWith(tolower(artifact_file), MAC_SUFFIX)) {
         writePackagesType <- 'mac.binary'
-        contribUrlType <- 'mac.binary.el-capitan'
+        contribUrlType <- if (startsWith(rversion, '4')) 'mac.binary' else 'mac.binary.el-capitan'
     } else if (endsWith(tolower(artifact_file), WINDOWS_SUFFIX)) {
         writePackagesType <- 'win.binary'
         contribUrlType <- 'win.binary'


### PR DESCRIPTION
R4 packages aren't expected to be in the separate el-capitan contrib folder on the RAN server, unlike 3.5 and 3.6 builds.

https://cran.r-project.org/bin/macosx/tools/