### PR TITLE
IT-2441: Allow autoMinorUpgrade

### DIFF
--- a/warehouse/dw_snapshot.py
+++ b/warehouse/dw_snapshot.py
@@ -163,7 +163,7 @@ def launch_snapshot(rds, db_id, subnet_group, instance_name, owner_email, projec
         DBSnapshotIdentifier=latest['DBSnapshotIdentifier'],
         DBSubnetGroupName=subnet_group,
         PubliclyAccessible=False,
-        AutoMinorVersionUpgrade=False,
+        AutoMinorVersionUpgrade=True,
         Tags=[
             {'Key':'OwnerEmail', 'Value':owner_email},
             {'Key':'Project', 'Value':project}


### PR DESCRIPTION
This PR creates the database with AutoMinorVersionUpgrade=True (to satisfy RDS.13 RDS automatic minor version upgrades should be enabled).It's fine for restored DW instances (no code running, just SQL from client for adhoc queries).